### PR TITLE
Fix missing database tables of Axon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,7 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jdbc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=username
+spring.datasource.password=password


### PR DESCRIPTION
Application would not start due to Axon not being able to find certain tables in the database schema in H2. Problem turned out to be using JDBC instead of JPA.

https://discuss.axoniq.io/t/using-axon-server-as-event-store-along-side-h2-for-projection-sid/4686